### PR TITLE
Support other react/react-native version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   "homepage": "https://github.com/mientjan/react-native-markdown-renderer#readme",
   "dependencies": {
     "markdown-it": "^8.3.1",
-    "react": "16.0.0-alpha.12",
-    "react-native": "0.45.1",
     "react-native-fit-image": "^1.4.9"
+  },
+  "peerDependencies": {
+    "react": ">=16.0.0-alpha.6",
+    "react-native": ">=0.44.0"
   }
 }


### PR DESCRIPTION
Couldn't make this package work with `react-native@0.46.4`, because of conflict in versions of RN 
Moving `react` and `react-native` to `peerDependencies` solved the problem for me