### PR TITLE
Fix incorrect props path for getCopyFromProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ export default class Markdown extends Component {
     }
   }
 
-  getCopyFromProps(props = this.props.children) {
+  getCopyFromProps(props = this.props) {
     return props.children instanceof Array
       ? props.children.join('')
       : props.children;


### PR DESCRIPTION
Otherwise it renders nothing, because there is no `this.props.children.children`.