### PR TITLE
Alignment improvements for Android in list items

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -1,10 +1,11 @@
 import React, { Component, PropTypes } from "react";
-import { Text, View } from "react-native";
+import { Platform, Text, View } from "react-native";
 
 import FitImage from "react-native-fit-image";
 import openUrl from "./util/openUrl";
 import hasParents from "./util/hasParents";
 import applyStyle from "./util/applyStyle";
+import PlatformEnum from "./enum/PlatformEnum";
 
 const renderRules = {
   // when unknown elements are introduced, so it wont break
@@ -163,7 +164,14 @@ const renderRules = {
     if (hasParents(parent, "bullet_list")) {
       return (
         <View key={node.key} style={styles.listUnorderedItem}>
-          <Text style={styles.listUnorderedItemIcon}>{"\u00B7"}</Text>
+          <Text
+            style={styles.listUnorderedItemIcon}
+          >
+            {Platform.select({
+                [PlatformEnum.ANDROID]: "\u2022",
+                [PlatformEnum.IOS]: "\u00B7"
+            })}
+          </Text>
           <View style={[styles.listItem]}>{children}</View>
         </View>
       );

--- a/src/lib/styles.js
+++ b/src/lib/styles.js
@@ -81,6 +81,11 @@ export const styles = StyleSheet.create({
     marginLeft: 10,
     marginRight: 10,
     ...Platform.select({
+      [PlatformEnum.ANDROID]: {
+        marginTop: 5
+      }
+    }),
+    ...Platform.select({
       [PlatformEnum.IOS]: {
         lineHeight: 36
       },
@@ -101,6 +106,11 @@ export const styles = StyleSheet.create({
   listOrderedItemIcon: {
     marginLeft: 10,
     marginRight: 10,
+    ...Platform.select({
+      [PlatformEnum.ANDROID]: {
+        marginTop: 4
+      }
+    }),
     ...Platform.select({
       [PlatformEnum.IOS]: {
         lineHeight: 36


### PR DESCRIPTION
Hi!

There is some alignment improvements for Android in list items. `Bullet` for unordered item also improved.

Before:
![screenshot_2018-02-15-16-52-00](https://user-images.githubusercontent.com/10154356/36253948-6aecdc5c-1273-11e8-9716-c8440c190eb2.png)

After:
![screenshot_2018-02-15-17-08-03](https://user-images.githubusercontent.com/10154356/36253964-77a3fbce-1273-11e8-95fa-bccf1d0ef7c8.png)
