### PR TITLE
Adding hardbreak rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-markdown-renderer",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Markdown renderer for react-native, with CommonMark spec support + adds syntax extensions & sugar (URL autolinking, typographer).",
   "main": "src/index.js",
   "scripts": {},

--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -112,6 +112,10 @@ const renderRules = {
     </View>
   ),
 
+  hardbreak: (node, children, parent, styles) => (
+    <View key={node.key} style={styles.hardbreak} />
+  ),
+
   blockquote: (node, children, parent, styles) => (
     <View key={node.key} style={styles.blockquote}>
       {children}

--- a/src/lib/styles.js
+++ b/src/lib/styles.js
@@ -122,6 +122,10 @@ export const styles = StyleSheet.create({
     alignItems: "flex-start",
     justifyContent: "flex-start"
   },
+  hardbreak: {
+    width: '100%',
+    height: 1
+  },
   strong: {
     fontWeight: "bold"
   },


### PR DESCRIPTION
Hardbreak Rule

It looks like it just transforms to a `br` in HTML.  I’m believe it’s an invisible character of `0x20` (based on the markdown-it lib):

Default:
https://github.com/markdown-it/markdown-it/blob/d57c83a4f1f8747c5781632291d195aa2e2154de/lib/renderer.js#L104

How it parses:
https://github.com/markdown-it/markdown-it/blob/master/lib/rules_inline/newline.js#L21