### PR TITLE
Use bullet character for ul instead of middle-dot

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -167,7 +167,7 @@ const renderRules = {
     if (hasParents(parent, "bullet_list")) {
       return (
         <View key={node.key} style={styles.listUnorderedItem}>
-          <Text style={styles.listUnorderedItemIcon}>{"\u00B7"}</Text>
+          <Text style={styles.listUnorderedItemIcon}>{"\u2022"}</Text>
           <View style={[styles.listItem]}>{children}</View>
         </View>
       );


### PR DESCRIPTION
The middle dot looks very small, the bullet seems like a better choice. Visually it is more appealing, and matches standard markdown renderers like in GitHub readmes.