### PR TITLE
feature/export-applyStyle: Add to index.js and index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,8 @@ import { MarkdownIt, Token } from 'markdown-it';
 import { ComponentType, ReactNode } from 'react';
 import { StyleSheet, View } from 'react-native';
 
+export function applyStyle(children: any[], styles: any, type: string): any;
+
 export function getUniqueID(): string;
 export function openUrl(url: string): void;
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { parser, stringToTokens } from './lib/parser';
+import applyStyle from './lib/util/applyStyle';
 import getUniqueID from './lib/util/getUniqueID';
 import hasParents from './lib/util/hasParents';
 import openUrl from './lib/util/openUrl';
@@ -21,6 +22,7 @@ import { styles } from './lib/styles';
  *
  */
 export {
+  applyStyle,
   getUniqueID,
   openUrl,
   hasParents,


### PR DESCRIPTION
This makes `applyStyle` a named export/import, thus enabling `import { applyStyle } from 'react-native-markdown-renderer'`.  This is needed if you want to define your own render rules to pass to RNMR and such rules need to call `applyStyle`.