### PR TITLE
Added root view style

### DIFF
--- a/src/lib/AstRenderer.js
+++ b/src/lib/AstRenderer.js
@@ -2,8 +2,8 @@ import React, { Component, PropTypes } from "react";
 import { Text, View } from "react-native";
 import getUniqueID from "./util/getUniqueID";
 
-export function rootRenderRule(children) {
-  return <View key={getUniqueID()}>{children}</View>;
+export function rootRenderRule(children, style) {
+  return <View key={getUniqueID()} style={style}>{children}</View>;
 }
 
 /**
@@ -66,6 +66,6 @@ export default class AstRenderer {
    */
   render = nodes => {
     const children = nodes.map(value => this.renderNode(value, []));
-    return rootRenderRule(children);
+    return rootRenderRule(children, this._style.view);
   };
 }


### PR DESCRIPTION
Currently, root view has no style applied.
With this PR, it's possible to do it through `view` style.

Example:
```js
import Markdown, { AstRenderer, renderRules, styles } from 'react-native-markdown-renderer';

const renderer = new AstRenderer({
    ...renderRules
}, {
    ...styles,
    view: {
        flex: 1,
        backgroundColor: 'blue'
    }
});

return <Markdown renderer={renderer.render}>Text</Markdown>
```

