### PR TITLE
pass style not styles to View in AstRenderer

### DIFF
--- a/src/lib/AstRenderer.js
+++ b/src/lib/AstRenderer.js
@@ -3,7 +3,7 @@ import { Text, View } from "react-native";
 import getUniqueID from "./util/getUniqueID";
 
 export function rootRenderRule(children, styles) {
-  return <View key={getUniqueID()} styles={styles.root}>{children}</View>;
+  return <View key={getUniqueID()} style={styles.root}>{children}</View>;
 }
 
 /**


### PR DESCRIPTION
Pass `style` not `styles` to `View` in `AstRenderer.js`. Bug was introduced in https://github.com/mientjan/react-native-markdown-renderer/commit/c6dd6849ee8768e8001eced66157033d99e7f036#diff-67c4045f2e21a3a58f12a603c5e19d69