### PR TITLE
Fixed numbering of ordered list items with text between items

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -177,9 +177,17 @@ const renderRules = {
     }
 
     if (hasParents(parent, 'ordered_list')) {
+      const orderedListIndex = parent.findIndex(el => el.type === 'ordered_list');
+      const orderedList = parent[orderedListIndex];
+      let listItemNumber;
+      if (orderedList.attributes && orderedList.attributes.start) {
+        listItemNumber = orderedList.attributes.start + node.index;
+      } else {
+        listItemNumber = node.index + 1;
+      }
       return (
         <View key={node.key} style={styles.listOrderedItem}>
-          <Text style={styles.listOrderedItemIcon}>{node.index + 1}{node.markup}</Text>
+          <Text style={styles.listOrderedItemIcon}>{listItemNumber}{node.markup}</Text>
           <View style={[styles.listItem]}>{children}</View>
         </View>
       );


### PR DESCRIPTION
When there is text between an ordered list's items, the numbers rendered are always 1. It seems like the list numbers are reset because of the text between the items, but this fixes that issue to keep behavior in line with markdown-it and CommonMark.

Fixes #57 