### PR TITLE
Changed hardbreak render to text

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -117,7 +117,11 @@ const renderRules = {
     </View>
   ),
 
-  hardbreak: (node, children, parent, styles) => <View key={node.key} style={styles.hardbreak} />,
+  hardbreak: (node, children, parent, styles) => (
+    <Text key={node.key} style={styles.hardbreak}>
+      {"\n"}
+    </Text>
+  ),
 
   blockquote: (node, children, parent, styles) => (
     <View key={node.key} style={styles.blockquote}>


### PR DESCRIPTION
Hardbreak renders a view which breaks on android as views can't be
inside texts. This is changed to a text with new line to work on both
platforms.