### PR TITLE
Support image alt text for accessibility

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -230,7 +230,20 @@ const renderRules = {
   // br
   softbreak: (node, children, parent, styles) => <Text key={node.key}>{'\n'}</Text>,
   image: (node, children, parent, styles) => {
-    return <FitImage indicator={true} key={node.key} style={styles.image} source={{ uri: node.attributes.src }} />;
+    const { src, alt } = node.attributes;
+    const imageProps = {
+      indicator: true,
+      key: node.key,
+      style: styles.image,
+      source: {
+        uri: src
+      }
+    };
+    if(alt) {
+      imageProps.accessible = true;
+      imageProps.accessibilityLabel = alt;
+    }
+    return <FitImage {...imageProps} />;
   },
 };
 

--- a/src/lib/util/cleanupTokens.js
+++ b/src/lib/util/cleanupTokens.js
@@ -1,5 +1,6 @@
 import getTokenTypeByToken from './getTokenTypeByToken';
 import flattenInlineTokens from './flattenInlineTokens';
+import renderInlineAsText from './renderInlineAsText';
 
 export function cleanupTokens(tokens) {
   tokens = flattenInlineTokens(tokens);
@@ -9,6 +10,11 @@ export function cleanupTokens(tokens) {
     // set image and hardbreak to block elements
     if (token.type === 'image' || token.type === 'hardbreak') {
       token.block = true;
+    }
+
+    // Set img alt text
+    if (token.type === 'image') {
+      token.attrs[token.attrIndex('alt')][1] = renderInlineAsText(token.children);
     }
   });
 

--- a/src/lib/util/renderInlineAsText.js
+++ b/src/lib/util/renderInlineAsText.js
@@ -1,0 +1,13 @@
+export default function renderInlineAsText(tokens) {
+  var result = '';
+
+  for (var i = 0, len = tokens.length; i < len; i++) {
+    if (tokens[i].type === 'text') {
+      result += tokens[i].content;
+    } else if (tokens[i].type === 'image') {
+      result += renderInlineAsText(tokens[i].children);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
The current implementation does not correctly parse alt text from an image, as the [markdown-it parser does not appear to support this out of the box](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_inline/image.js#L140).

As taken from the [markdown-it renderer source](https://github.com/markdown-it/markdown-it/blob/d57c83a4f1f8747c5781632291d195aa2e2154de/lib/renderer.js#L89-L101), this PR adds the alt text attribute so it can be used by the image render rule. The default rule passes this through as an accessibilityLabel, so it can be read by VoiceOver.