### PR TITLE
Fix styling vor text not beeing applied consistently

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -29,7 +29,7 @@ const renderRules = {
   },
 
   text: (node, children, parent, styles) => {
-    return <Text key={node.key}>{node.content}</Text>;
+    return <Text key={node.key} style={styles.text}>{node.content}</Text>;
   },
   span: (node, children, parent, styles) => {
     return <Text key={node.key}>{children}</Text>;


### PR DESCRIPTION
Supplying lineHeight to the props.style.text styles would not be rendered, because the 'textgroup' does not hand down the style to its 'text' rules.