### PR TITLE
 move @types/react-native to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/mientjan/react-native-markdown-renderer#readme",
   "dependencies": {
     "@types/markdown-it": "^0.0.4",
-    "@types/react-native": ">=0.50.0",
     "markdown-it": "^8.4.0",
     "prop-types": "^15.5.10",
     "react-native-fit-image": "^1.5.2"
@@ -33,6 +32,7 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-native": "^0.50.4"
+    "@types/react-native": ">=0.50.0",
   },
   "devDependencies": {
     "chokidar": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "react-native-fit-image": "^1.5.2"
   },
   "peerDependencies": {
+    "@types/react-native": ">=0.50.0",
     "react": "^16.2.0",
     "react-native": "^0.50.4"
-    "@types/react-native": ">=0.50.0",
   },
   "devDependencies": {
     "chokidar": "^2.0.0",


### PR DESCRIPTION
put `@types/react-native` in `dependencies` makes duplicated variables, definition.. if types check is enabled