### PR TITLE
Move @types/react-native to Peer Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   "homepage": "https://github.com/mientjan/react-native-markdown-renderer#readme",
   "dependencies": {
     "@types/markdown-it": "^0.0.4",
-    "@types/react-native": ">=0.50.0",
     "markdown-it": "^8.4.0",
     "prop-types": "^15.5.10",
     "react-native-fit-image": "^1.5.2"
   },
   "peerDependencies": {
     "react": "^16.2.0",
-    "react-native": "^0.50.4"
+    "react-native": "^0.50.4",
+    "@types/react-native": ">=0.50.0"
   },
   "devDependencies": {
     "chokidar": "^2.0.0",


### PR DESCRIPTION
# Summary

Moves the `@types/react-native` dependency to peer dependencies. 

For context, this is useful because otherwise, a user of this library with a direct dependency on `@types/react-native` can wind up with two different versions of the `@types/react-native` installed, one under `node_modules/@types/react-native` and one under `node_modules/react-native-markdown-renderer/node_modules/@types/react-native`. That results in TypeScript errors like:

```
node_modules/react-native-markdown-renderer/node_modules/@types/react-native/index.d.ts:9488:11 - error TS2451: Cannot redeclare block-scoped variable 'originalXMLHttpRequest'.

9488     const originalXMLHttpRequest: any;
               ~~~~~~~~~~~~~~~~~~~~~~

  node_modules/@types/react-native/index.d.ts:9574:11
    9574     const originalXMLHttpRequest: any;
                   ~~~~~~~~~~~~~~~~~~~~~~
    'originalXMLHttpRequest' was also declared here.
```

This should resolve https://github.com/mientjan/react-native-markdown-renderer/issues/53. 

There's another PR for this here: https://github.com/mientjan/react-native-markdown-renderer/pull/113, but it appears to make extraneous changes and hasn't seen any responses. I don't mean to step on any toes, just figured this was a more direct way to get a more focused PR up.

I only have a sample size of 1, but this change works in my project, and does not break the existing typing as far as I can tell.

If there's anything I can do to help get this across the line, please let me know.