### PR TITLE
Correctly specify peerDependencies of react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "react": "^16.2.0",
-    "react-native": "^0.50.4"
+    "react-native": ">=0.50.4"
   },
   "devDependencies": {
     "chokidar": "^2.0.0",


### PR DESCRIPTION
Fix #117 

According to https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004

^0.50.4 will only put the version between `0.50.0 ~ 0.51.0`