### PR TITLE
Added sourceInfo to ASTNode

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,6 +30,7 @@ export interface MarkdownParser {
 export interface ASTNode {
   type: string;
   sourceType: string; // original source token name
+  sourceInfo: string;
   key: string;
   content: string;
   tokenIndex: number;


### PR DESCRIPTION
In case you need syntax highlighting with Prism or something similar, you need to get the language of code via node.sourceInfo like this:

```javascript
<Markdown
          rules={{
            // markdown-it renders code blocks as "fence".
            fence: (node) => {
              return (
                <CodeBlock
                  key={node.key}
                  plainCode={node.content}

                  // Get the language
                  lang={node.sourceInfo}
                />
              );
            },
          }}
        >
          {wholeMarkdown}
        </Markdown>
```

And then the component:

```javascript
import Prism from 'prismjs';

const CodeBlock = ({ plainCode, lang }) => {
  let highlightedCode: string = '';
  try {
    highlightedCode = Prism.highlight(plainCode, Prism.languages[lang], lang);
  } catch (_) {
    highlightedCode = plainCode;
  }

  return ... // Use react-native-render-html (recommended) or react-native-webview to show the highlighted code.
};
```